### PR TITLE
Initial implementation of API client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ env/
 terraform.tfstate
 __pycache__
 static/
+node_modules/

--- a/dashboard_service/dashboards/api.py
+++ b/dashboard_service/dashboards/api.py
@@ -1,18 +1,25 @@
 import time
+from typing import Any
 
 import requests
 from django.conf import settings
 
 
 class ControlPanelApiClient:
-    def __init__(self):
-        self.access_token = None
-        self.token_expiry = None
-        self.base_url = settings.CONTROL_PANEL_API_URL
+    def __init__(self) -> None:
+        self.access_token: str | None = None
+        self.token_expiry: int | None = None
+        self.base_url: str = settings.CONTROL_PANEL_API_URL
 
-    def get_access_token(self):
-        token_url = f"http://{settings.AUTH0_DOMAIN}/oauth/token"
-        data = {
+    def get_access_token(self) -> dict[str, Any]:
+        """
+        Request a new access token from Auth0
+
+        Returns:
+            Dict containing access_token and expires_in values
+        """
+        token_url = f"https://{settings.AUTH0_DOMAIN}/oauth/token"
+        data: dict[str, str] = {
             "client_id": settings.AUTH0_CLIENT_ID,
             "client_secret": settings.AUTH0_CLIENT_SECRET,
             "audience": settings.AUTH0_AUDIENCE,
@@ -24,30 +31,44 @@ class ControlPanelApiClient:
 
     def token_expired(self) -> bool:
         """
-        Check if we shold get a new access token
+        Check if we should get a new access token
+
+        Returns:
+            True if token is expired or missing, False otherwise
         """
         if not all([self.access_token, self.token_expiry]):
             return True
         current_time = int(time.time()) + 300  # 5 minute buffer
         return self.token_expiry < current_time
 
-    def ensure_valid_token(self):
+    def ensure_valid_token(self) -> str:
         """
         Get a valid access token, refreshing only if necessary
+
+        Returns:
+            A valid access token
         """
         if not self.token_expired():
             return self.access_token
 
-        token_data = self.get_access_token()
+        token_data: dict[str, Any] = self.get_access_token()
         self.access_token = token_data["access_token"]
-        self.token_expiry = time.time() + token_data["expires_in"]
+        self.token_expiry = int(time.time()) + token_data["expires_in"]
         return self.access_token
 
-    def make_request(self, endpoint, method="GET", **kwargs):
+    def make_request(self, endpoint: str, method: str = "GET", **kwargs: Any) -> dict[str, Any]:
         """
         Make an authenticated request to the API
+
+        Args:
+            endpoint: API endpoint path
+            method: HTTP method (GET, POST, etc.)
+            **kwargs: Additional arguments to pass to requests.request
+
+        Returns:
+            JSON response from the API
         """
-        token = self.ensure_valid_token()
+        token: str = self.ensure_valid_token()
 
         headers = kwargs.get("headers", {})
         headers["Authorization"] = f"Bearer {token}"

--- a/dashboard_service/dashboards/api.py
+++ b/dashboard_service/dashboards/api.py
@@ -1,0 +1,62 @@
+import time
+
+import requests
+from django.conf import settings
+
+
+class ControlPanelApiClient:
+    def __init__(self):
+        self.access_token = None
+        self.token_expiry = None
+        self.base_url = settings.CONTROL_PANEL_API_URL
+
+    def get_access_token(self):
+        token_url = f"http://{settings.AUTH0_DOMAIN}/oauth/token"
+        data = {
+            "client_id": settings.AUTH0_CLIENT_ID,
+            "client_secret": settings.AUTH0_CLIENT_SECRET,
+            "audience": settings.AUTH0_AUDIENCE,
+            "grant_type": "client_credentials",
+        }
+        response = requests.post(url=token_url, data=data)
+        response.raise_for_status()
+        return response.json()
+
+    def token_expired(self) -> bool:
+        """
+        Check if we shold get a new access token
+        """
+        if not all([self.access_token, self.token_expiry]):
+            return True
+        current_time = int(time.time()) + 300  # 5 minute buffer
+        return self.token_expiry < current_time
+
+    def ensure_valid_token(self):
+        """
+        Get a valid access token, refreshing only if necessary
+        """
+        if not self.token_expired():
+            return self.access_token
+
+        token_data = self.get_access_token()
+        self.access_token = token_data["access_token"]
+        self.token_expiry = time.time() + token_data["expires_in"]
+        return self.access_token
+
+    def make_request(self, endpoint, method="GET", **kwargs):
+        """
+        Make an authenticated request to the API
+        """
+        token = self.ensure_valid_token()
+
+        headers = kwargs.get("headers", {})
+        headers["Authorization"] = f"Bearer {token}"
+        kwargs["headers"] = headers
+        url = f"{self.base_url}{endpoint}"
+
+        response = requests.request(method, url, **kwargs)
+        response.raise_for_status()
+        return response.json()
+
+
+api_client = ControlPanelApiClient()

--- a/dashboard_service/dashboards/urls.py
+++ b/dashboard_service/dashboards/urls.py
@@ -6,4 +6,5 @@ app_name = "dashboards"
 
 urlpatterns = [
     path("", views.IndexView.as_view(), name="index"),
+    path("<str:quicksight_id>/", views.DetailView.as_view(), name="detail"),
 ]

--- a/dashboard_service/dashboards/views.py
+++ b/dashboard_service/dashboards/views.py
@@ -27,7 +27,8 @@ class DetailView(TemplateView):
         context = super().get_context_data(**kwargs)
         try:
             context["dashboard"] = api_client.make_request(
-                f"dashboards/{kwargs['quicksight_id']}", params={"email": self.request.user.email}
+                f"dashboards/{self.kwargs['quicksight_id']}",
+                params={"email": self.request.user.email},
             )
         except requests.exceptions.HTTPError as e:
             raise Http404() from e

--- a/dashboard_service/dashboards/views.py
+++ b/dashboard_service/dashboards/views.py
@@ -1,5 +1,9 @@
+import requests
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.http import Http404
 from django.views.generic import TemplateView
+
+from dashboard_service.dashboards.api import api_client
 
 
 class IndexView(LoginRequiredMixin, TemplateView):
@@ -8,3 +12,24 @@ class IndexView(LoginRequiredMixin, TemplateView):
     """
 
     template_name = "dashboards/index.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["dashboards"] = api_client.make_request(
+            "dashboards", params={"email": self.request.user.email}
+        )["results"]
+        return context
+
+
+class DetailView(LoginRequiredMixin, TemplateView):
+    template_name = "dashboards/detail.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        try:
+            context["dashboard"] = api_client.make_request(
+                f"dashboards/{kwargs['quicksight_id']}", params={"email": self.request.user.email}
+            )
+        except requests.exceptions.HTTPError as e:
+            raise Http404() from e
+        return context

--- a/dashboard_service/dashboards/views.py
+++ b/dashboard_service/dashboards/views.py
@@ -1,12 +1,11 @@
 import requests
-from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import Http404
 from django.views.generic import TemplateView
 
 from dashboard_service.dashboards.api import api_client
 
 
-class IndexView(LoginRequiredMixin, TemplateView):
+class IndexView(TemplateView):
     """
     Index view for the dashboard service.
     """
@@ -21,7 +20,7 @@ class IndexView(LoginRequiredMixin, TemplateView):
         return context
 
 
-class DetailView(LoginRequiredMixin, TemplateView):
+class DetailView(TemplateView):
     template_name = "dashboards/detail.html"
 
     def get_context_data(self, **kwargs):

--- a/dashboard_service/settings/common.py
+++ b/dashboard_service/settings/common.py
@@ -143,7 +143,7 @@ LOGIN_URL = "login"
 AUTH0_DOMAIN = os.environ.get("AUTH0_DOMAIN")
 AUTH0_CLIENT_ID = os.environ.get("AUTH0_CLIENT_ID")
 AUTH0_CLIENT_SECRET = os.environ.get("AUTH0_CLIENT_SECRET")
-
+AUTH0_AUDIENCE = os.environ.get("AUTH0_AUDIENCE")
 # Authlib
 AUTHLIB_OAUTH_CLIENTS = {
     "auth0": {
@@ -156,3 +156,6 @@ AUTHLIB_OAUTH_CLIENTS = {
         "authorize_params": {"isPasswordlessFlow": True},  # required to trigger passwordless login
     }
 }
+
+# Control Panel API settings
+CONTROL_PANEL_API_URL = os.environ.get("CONTROL_PANEL_API_URL")

--- a/dashboard_service/settings/common.py
+++ b/dashboard_service/settings/common.py
@@ -50,6 +50,7 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.auth.middleware.LoginRequiredMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]

--- a/dashboard_service/urls.py
+++ b/dashboard_service/urls.py
@@ -22,11 +22,12 @@ from django.urls import include, path
 from dashboard_service import views
 
 urlpatterns = [
+    path("", views.index, name="index"),
     path("admin/", admin.site.urls),
-    path("", include("dashboard_service.dashboards.urls", namespace="dashboards")),
     path("login/", views.login, name="login"),
-    path("logout/", views.logout, name="logout"),
     path("callback/", views.callback, name="callback"),
+    path("logout/", views.logout, name="logout"),
+    path("dashboards/", include("dashboard_service.dashboards.urls", namespace="dashboards")),
 ]
 
 

--- a/justfile
+++ b/justfile
@@ -49,4 +49,4 @@ destroy:
     dropdb --if-exists {{ db_name }}
 
 test *ARGS:
-    pytest . --failed-first {{ ARGS}}
+    pytest . --failed-first --maxfail=5 {{ ARGS }}

--- a/justfile
+++ b/justfile
@@ -48,5 +48,5 @@ destroy:
     rm -rf .venv/
     dropdb --if-exists {{ db_name }}
 
-test:
-    pytest . --failed-first
+test *ARGS:
+    pytest . --failed-first {{ ARGS}}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,3 +43,5 @@ select = [
 
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "dashboard_service.settings.test"
+addopts = "-v --tb=auto"
+testpaths = ["tests"]

--- a/templates/base.html
+++ b/templates/base.html
@@ -3,5 +3,10 @@
 
 {% block title %}Analytical Platform Dashboard Service{% endblock title %}
 
-{% block content %}
-{% endblock content %}
+<body class="govuk-template__body govuk-frontend-supported" {% block body_attributes %}{% endblock body_attributes %}>
+    {% block content %}
+    {% endblock content %}
+
+    {% block scripts %}
+    {% endblock scripts %}
+</body>

--- a/templates/dashboards/detail.html
+++ b/templates/dashboards/detail.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+
+{% block content %}
+    <h1>Dashboard {{dashboard.name }}</h1>
+
+    <iframe
+        width="960"
+        height="720"
+        src="{{ dashboard.embed_url }}">
+    </iframe>
+
+{% endblock content %}

--- a/templates/dashboards/detail.html
+++ b/templates/dashboards/detail.html
@@ -1,12 +1,96 @@
 {% extends "base.html" %}
 
+{% block body_attributes %}onload="embedDashboard()"{% endblock body_attributes %}
+
+{% block title %}Analytical Platform Dashboard Service{% endblock title %}
+
 {% block content %}
     <h1>Dashboard {{dashboard.name }}</h1>
 
-    <iframe
-        width="960"
-        height="720"
-        src="{{ dashboard.embed_url }}">
-    </iframe>
+    <p>Admins: {{ dashboard.admins }}</p>
+
+    <body onload="embedDashboard()">
+        <div id="experience-container"></div>
+    </body>
 
 {% endblock content %}
+
+{% block scripts %}
+    <script src="https://unpkg.com/amazon-quicksight-embedding-sdk@2.10.0/dist/quicksight-embedding-js-sdk.min.js"></script>
+    <script type="text/javascript">
+        const embedDashboard = async() => {
+            const {
+                createEmbeddingContext,
+            } = QuickSightEmbedding;
+
+            const embeddingContext = await createEmbeddingContext({
+                onChange: (changeEvent, metadata) => {
+                    console.log('Context received a change', changeEvent, metadata);
+                },
+            });
+
+            const frameOptions = {
+                url: '{{ dashboard.embed_url|safe }}',
+                container: '#experience-container',
+                height: window.screen.availHeight * 0.80,
+                width: "100%",
+                onChange: (changeEvent, metadata) => {
+                    switch (changeEvent.eventName) {
+                        case 'FRAME_MOUNTED': {
+                            console.log("Do something when the experience frame is mounted.");
+                            break;
+                        }
+                        case 'FRAME_LOADED': {
+                            console.log("Do something when the experience frame is loaded.");
+                            break;
+                        }
+                    }
+                },
+            };
+
+            const contentOptions = {
+                locale: "en-GB",
+                toolbarOptions: {
+                    export: true,
+                    undoRedo: true,
+                    reset: true
+                },
+                attributionOptions: {
+                    overlayContent: false,
+                },
+                onMessage: async (messageEvent, experienceMetadata) => {
+                    switch (messageEvent.eventName) {
+                        case 'CONTENT_LOADED': {
+                            console.log("All visuals are loaded. The title of the document:", messageEvent.message.title);
+                            break;
+                        }
+                        case 'ERROR_OCCURRED': {
+                            console.log("Error occurred while rendering the experience. Error code:", messageEvent.message.errorCode);
+                            break;
+                        }
+                        case 'PARAMETERS_CHANGED': {
+                            console.log("Parameters changed. Changed parameters:", messageEvent.message.changedParameters);
+                            break;
+                        }
+                        case 'SELECTED_SHEET_CHANGED': {
+                            console.log("Selected sheet changed. Selected sheet:", messageEvent.message.selectedSheet);
+                            break;
+                        }
+                        case 'SIZE_CHANGED': {
+                            console.log("Size changed. New dimensions:", messageEvent.message);
+                            break;
+                        }
+                        case 'MODAL_OPENED': {
+                            window.scrollTo({
+                                top: 0 // iframe top position
+                            });
+                            break;
+                        }
+                    }
+                },
+            };
+            const embeddedDashboardExperience = await embeddingContext.embedDashboard(frameOptions, contentOptions);
+        };
+    </script>
+
+{% endblock scripts %}

--- a/templates/dashboards/index.html
+++ b/templates/dashboards/index.html
@@ -2,4 +2,12 @@
 
 {% block content %}
     <h1>Dashboard List</h1>
+
+    <div>
+        {% for dashboard in dashboards %}
+            <p>{{ dashboard.name }}</p>
+            <p>{{ dashboard.quicksight_id }}</p>
+            <p>{{ dashboard.admins }}</p>
+        {% endfor %}
+    </div>
 {% endblock content %}

--- a/templates/dashboards/index.html
+++ b/templates/dashboards/index.html
@@ -8,6 +8,7 @@
             <p>{{ dashboard.name }}</p>
             <p>{{ dashboard.quicksight_id }}</p>
             <p>{{ dashboard.admins }}</p>
+            <p><a href="{% url "dashboards:detail" quicksight_id=dashboard.quicksight_id %}">View dashboard</a></p>
         {% endfor %}
     </div>
 {% endblock content %}

--- a/templates/dashboards/index.html
+++ b/templates/dashboards/index.html
@@ -6,7 +6,6 @@
     <div>
         {% for dashboard in dashboards %}
             <p>{{ dashboard.name }}</p>
-            <p>{{ dashboard.quicksight_id }}</p>
             <p>{{ dashboard.admins }}</p>
             <p><a href="{% url "dashboards:detail" quicksight_id=dashboard.quicksight_id %}">View dashboard</a></p>
         {% endfor %}

--- a/tests/dashboard_service/conftest.py
+++ b/tests/dashboard_service/conftest.py
@@ -1,0 +1,24 @@
+from unittest.mock import patch
+
+import pytest
+
+from dashboard_service.dashboards.api import api_client as _api_client
+
+
+@pytest.fixture(autouse=True)
+def mock_requests():
+    """
+    Make sure the requests library is always mocked.
+    """
+    with patch("dashboard_service.dashboards.api.requests") as mock_requests:
+        yield mock_requests
+
+
+@pytest.fixture()
+def api_client():
+    """
+    Fixture to reset the API client before each test.
+    """
+    _api_client.access_token = None
+    _api_client.token_expiry = None
+    yield _api_client

--- a/tests/dashboard_service/test_api.py
+++ b/tests/dashboard_service/test_api.py
@@ -1,0 +1,102 @@
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.conf import settings
+
+# from dashboard_service.dashboards.api import api_client
+
+
+def test_get_access_token(api_client, mock_requests):
+    """
+    Test that get_access_token makes the correct request to Auth0 and returns the response.
+    """
+    mock_token_data = {
+        "access_token": "mock_token_123",
+        "expires_in": 86400,  # 24 hours in seconds
+    }
+    mock_response = MagicMock()
+    mock_response.json.return_value = mock_token_data
+    mock_requests.post.return_value = mock_response
+
+    result = api_client.get_access_token()
+
+    assert result == mock_token_data
+    mock_requests.post.assert_called_once_with(
+        url=f"https://{settings.AUTH0_DOMAIN}/oauth/token",
+        data={
+            "client_id": settings.AUTH0_CLIENT_ID,
+            "client_secret": settings.AUTH0_CLIENT_SECRET,
+            "audience": settings.AUTH0_AUDIENCE,
+            "grant_type": "client_credentials",
+        },
+    )
+    mock_response.json.assert_called_once()
+    mock_response.raise_for_status.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "access_token, token_expiry, expected",
+    [
+        (None, None, True),
+        ("mock_token_123", None, True),
+        (None, 1234567890, True),
+        ("mock_token_123", 1000000000, True),
+        ("mock_token_123", int(time.time()) + 290, True),  # within the 5 min buffer
+        ("mock_token_123", int(time.time()) + 500, False),  # valid token
+    ],
+)
+def test_token_expired(access_token, token_expiry, expected, api_client):
+    api_client.access_token = access_token
+    api_client.token_expiry = token_expiry
+    assert api_client.token_expired() is expected
+
+
+def test_ensure_valid_token_token_valid(api_client):
+    with patch.object(api_client, "token_expired", return_value=False):
+        api_client.access_token = "mock_token_123"
+        assert api_client.ensure_valid_token() == "mock_token_123"
+        api_client.token_expired.assert_called_once()
+
+
+def test_ensure_valid_token_token_expired(api_client):
+    api_client.access_token = None
+    with patch.object(api_client, "get_access_token") as mock_get_access_token:
+        mock_get_access_token.return_value = {
+            "access_token": "mock_token_456",
+            "expires_in": 86400,
+        }
+        assert api_client.ensure_valid_token() == "mock_token_456"
+        mock_get_access_token.assert_called_once()
+        assert api_client.access_token == "mock_token_456"
+        assert api_client.token_expiry == int(time.time()) + 86400
+
+
+@pytest.mark.parametrize(
+    "endpoint, method, params",
+    [
+        ("mock_endpoint", "GET", {}),
+        ("mock_endpoint", "POST", {}),
+        ("mock_endpoint", "PUT", {}),
+        ("mock_endpoint", "DELETE", {}),
+        ("mock_endpoint", "GET", {"param1": "test1", "param2": "test2"}),
+    ],
+)
+def test_make_request(endpoint, method, params, api_client, mock_requests):
+    """
+    Test that make_request calls the requests library with the correct parameters.
+    """
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"key": "value"}
+    mock_requests.request.return_value = mock_response
+    api_client.access_token = "mock_token_123"
+
+    with patch.object(api_client, "ensure_valid_token", return_value="mock_token_123"):
+        result = api_client.make_request(endpoint, method=method, **params)
+
+        assert result == {"key": "value"}
+        mock_requests.request.assert_called_once_with(
+            method,
+            f"{api_client.base_url}{endpoint}",
+            headers={"Authorization": f"Bearer {api_client.access_token}"},
+        )

--- a/tests/dashboard_service/test_api.py
+++ b/tests/dashboard_service/test_api.py
@@ -4,8 +4,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 from django.conf import settings
 
-# from dashboard_service.dashboards.api import api_client
-
 
 def test_get_access_token(api_client, mock_requests):
     """

--- a/tests/dashboard_service/test_api.py
+++ b/tests/dashboard_service/test_api.py
@@ -99,4 +99,5 @@ def test_make_request(endpoint, method, params, api_client, mock_requests):
             method,
             f"{api_client.base_url}{endpoint}",
             headers={"Authorization": f"Bearer {api_client.access_token}"},
+            **params,
         )

--- a/tests/dashboard_service/test_views.py
+++ b/tests/dashboard_service/test_views.py
@@ -1,12 +1,38 @@
+from unittest.mock import patch
+
 import pytest
 from django.conf import settings
 from django.urls import reverse
 
+from dashboard_service.dashboards import views
 from dashboard_service.users.models import User
 
 
-@pytest.mark.django_db
+@pytest.fixture
+def user():
+    return User(username="testuser", email="test@example.com")
+
+
+@pytest.fixture(autouse=True)
+def authenticated_api_client(api_client):
+    """
+    Patch the api_client to always return a valid token
+    """
+    with patch.object(api_client, "token_expired", return_value=False):
+        yield api_client
+
+
 class TestIndexView:
+    @pytest.fixture
+    def view_obj(self, rf):
+        """
+        Fixture to create an instance of IndexView with a request object
+        """
+        request = rf.get(reverse("dashboards:index"))
+        view_obj = views.IndexView()
+        view_obj.request = request
+        yield view_obj
+
     def test_index_requires_login(self, client):
         url = reverse("dashboards:index")
 
@@ -15,12 +41,58 @@ class TestIndexView:
         assert response.status_code == 302
         assert settings.LOGIN_URL in response.url
 
-    def test_index_returns_200_for_authenticated_user(self, client):
+    @pytest.mark.django_db
+    def test_login_required(self, client, user):
         url = reverse("dashboards:index")
-        user = User.objects.create(username="testuser", email="test@example.com")
+        user.save()
         client.force_login(user)
 
         response = client.get(url)
 
         assert response.status_code == 200
         assert "dashboards/index.html" in [t.name for t in response.templates]
+
+    def test_get_context_data(self, api_client, view_obj, user):
+        view_obj.request.user = user
+
+        with patch.object(api_client, "make_request") as mock_make_request:
+            context = view_obj.get_context_data()
+
+        assert "dashboards" in context
+        mock_make_request.assert_called_once_with("dashboards", params={"email": user.email})
+
+
+class TestDetailView:
+    @pytest.fixture
+    def view_obj(self, rf):
+        """
+        Fixture to create an instance of IndexView with a request object
+        """
+        request = rf.get(reverse("dashboards:index"))
+        view_obj = views.DetailView(kwargs={"quicksight_id": "test_id"})
+        view_obj.request = request
+        yield view_obj
+
+    @pytest.mark.django_db
+    def test_login_required(self, client, user):
+        url = reverse("dashboards:detail", kwargs={"quicksight_id": "test_id"})
+        response = client.get(url)
+
+        assert response.status_code == 302
+        assert settings.LOGIN_URL in response.url
+
+        user.save()
+        client.force_login(user)
+        response = client.get(url)
+        # assert response.status_code == 200
+
+    def test_get_context_data(self, api_client, view_obj, user):
+        view_obj.request.user = user
+
+        with patch.object(api_client, "make_request") as mock_make_request:
+            context = view_obj.get_context_data()
+
+        assert "dashboard" in context
+        mock_make_request.assert_called_once_with(
+            f"dashboards/{view_obj.kwargs['quicksight_id']}", params={"email": user.email}
+        )

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,5 @@
+from dashboard_service.settings.common import MIDDLEWARE
+
+
+def test_login_required_middleware_enabled():
+    assert "django.contrib.auth.middleware.LoginRequiredMiddleware" in MIDDLEWARE

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,11 +1,14 @@
 from unittest.mock import Mock, patch
 
+from django.contrib.auth.models import AnonymousUser
+
 from dashboard_service.views import callback, login, logout
 
 
 @patch("dashboard_service.views.reverse", return_value="/callback/")
 def test_login_calls_authorize_redirect_correctly(mock_reverse, mock_auth0, rf):
     request = rf.get("/login/")
+    request.user = AnonymousUser()
     expected_redirect_uri = "http://testserver/callback/"
     request.build_absolute_uri = Mock(return_value=expected_redirect_uri)
 
@@ -33,7 +36,7 @@ def test_callback_authenticates_and_redirects(mock_get_or_create, mock_login, rf
     )
     mock_login.assert_called_once_with(request, user=user)
     assert response.status_code == 302
-    assert response.url == "/"
+    assert response.url == "/dashboards/"
 
 
 @patch("dashboard_service.views.urlencode")


### PR DESCRIPTION
Adds an API Client to interact with the Control Panel API. The client will:
- Request an access token to the Control Panel API, via auth0
- Before making a request, check the validity of the access token. If it has expired, requests a new one
- Make a request to the control panel API and return the respose

To run locally, there are some prerequisites:
- Control Panel is running branch `feature/dashboard-api-endpoints` locally on port 8000
- Grant your email address access to at least one dashboard. You may need to create a dashboard in Quicksight and register it in Control Panel if you have not done so already
- I also had to make some minor changes to the Control Panel code - i've detailed them on the [open PR](https://github.com/ministryofjustice/analytics-platform-control-panel/pull/1504#discussion_r2037692147) here

Then:
- Update your local .env file with the file stored in 1password
- Update dependencies and run the server with `just dev`
- Login via email (use @justice.gov.uk email)
- Visit http://localhost:8001/dashboards/ to see a list of your dashboard.
- Use the link on the list view to navigate to the detail view, where the dashboard is embedded

To run the tests locally:
- `just test`

Tests cannot run in CI yet as they depend on a database - this will be implemented as part of https://github.com/ministryofjustice/analytical-platform/issues/7546