### PR TITLE
Release/0.1.2

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 name: dashboard-service
 description: Analytical Platform Dashboard Service
 type: application
-version: 0.1.1
-appVersion: 0.1.1
+version: 0.1.2
+appVersion: 0.1.2
 icon: https://upload.wikimedia.org/wikipedia/en/thumb/4/4a/Ministry_of_Justice_logo_%28United_Kingdom%29.svg/611px-Ministry_of_Justice_logo_%28United_Kingdom%29.svg.png
 maintainers:
   - name: moj-data-platform-robot

--- a/dashboard_service/settings/development.py
+++ b/dashboard_service/settings/development.py
@@ -3,3 +3,10 @@ from .production import *  # noqa: F401, F403
 DEBUG = True
 
 ALLOWED_HOSTS += ["dashboards.development.analytical-platform.service.justice.gov.uk"]  # noqa: F405
+
+AUTH0_DOMAIN = "dev-analytics-moj.eu.auth0.com"
+AUTH0_AUDIENCE = "urn:control-panel-dev-api"
+
+CONTROL_PANEL_API_URL = (
+    "https://controlpanel.services.dev.analytical-platform.service.justice.gov.uk/api/cpanel/v1/"
+)

--- a/dashboard_service/settings/production.py
+++ b/dashboard_service/settings/production.py
@@ -7,3 +7,10 @@ DEBUG = False
 ALLOWED_HOSTS = ["dashboards.analytical-platform.service.justice.gov.uk"]
 
 ALLOWED_HOSTS.append(gethostbyname(gethostname()))
+
+AUTH0_DOMAIN = "alpha-analytics-moj.eu.auth0.com"
+AUTH0_AUDIENCE = "urn:control-panel-prod-api"
+
+CONTROL_PANEL_API_URL = (
+    "https://controlpanel.services.analytical-platform.service.justice.gov.uk/api/cpanel/v1/"
+)


### PR DESCRIPTION
Release a new version of the app with some missing settings.

I checked if any of the auth0 values were sensitive, but this is not the case they are all publicly viewable. Therefore decided to add these in their respective settings files for simplicity, rather than add as secrets that are exposed to the app via env vars.