### PR TITLE
Add login fail page

### DIFF
--- a/dashboard_service/urls.py
+++ b/dashboard_service/urls.py
@@ -25,8 +25,9 @@ urlpatterns = [
     path("", views.index, name="index"),
     path("admin/", admin.site.urls),
     path("login/", views.login, name="login"),
-    path("callback/", views.callback, name="callback"),
+    path("login-fail/", views.login_fail, name="login-fail"),
     path("logout/", views.logout, name="logout"),
+    path("callback/", views.callback, name="callback"),
     path("dashboards/", include("dashboard_service.dashboards.urls", namespace="dashboards")),
     path("healthcheck/", views.healthcheck, name="healthcheck"),
 ]

--- a/templates/base/header.html
+++ b/templates/base/header.html
@@ -11,7 +11,11 @@
       <nav class="moj-header__navigation" aria-label="Account navigation">
         <ul class="moj-header__navigation-list">
           <li class="moj-header__navigation-item">
-            <a class="moj-header__navigation-link" href="{% url "logout" %}">Sign out</a>
+            {% if request.user.is_authenticated %}
+              <a class="moj-header__navigation-link" href="{% url "logout" %}">Sign out</a>
+            {% else %}
+              <a class="moj-header__navigation-link" href="{% url "login" %}">Login</a>
+            {% endif %}
           </li>
         </ul>
       </nav>
@@ -19,16 +23,18 @@
   </div>
 </header>
 
-<div class="moj-primary-navigation">
-  <div class="moj-primary-navigation__container">
-    <div class="moj-primary-navigation__nav">
-      <nav class="moj-primary-navigation" aria-label="Primary navigation">
-        <ul class="moj-primary-navigation__list">
-          <li class="moj-primary-navigation__item">
-            <a class="moj-primary-navigation__link" aria-current="page" href="{% url "dashboards:index" %}">Dashboards</a>
-          </li>
-        </ul>
-      </nav>
+{% if request.user.is_authenticated %}
+  <div class="moj-primary-navigation">
+    <div class="moj-primary-navigation__container">
+      <div class="moj-primary-navigation__nav">
+        <nav class="moj-primary-navigation" aria-label="Primary navigation">
+          <ul class="moj-primary-navigation__list">
+            <li class="moj-primary-navigation__item">
+              <a class="moj-primary-navigation__link" aria-current="page" href="{% url "dashboards:index" %}">Dashboards</a>
+            </li>
+          </ul>
+        </nav>
+      </div>
     </div>
   </div>
-</div>
+{% endif %}

--- a/templates/login/login_fail.html
+++ b/templates/login/login_fail.html
@@ -5,8 +5,8 @@
 <div class="govuk-grid-row">
   <div class="govuk-width-container">
     <h1 class="govuk-heading-l">Login failed</h1>
-    <p class="govuk-body">We were unable to log you in, <a href="{% url "login" %}">please retry</a>.</p>
-    <p class="govuk-body">If the problem persists contact Analytical Platform support.</p>
+    <p class="govuk-body">We were unable to log you in, <a href="{% url "login" %}" class="govuk-link">please retry</a>.</p>
+    <p class="govuk-body">If the problem persists email Analytical Platform at <a href="mailto:analytical-platform@justice.gov.uk" class="govuk-link">analytical-platform@justice.gov.uk</a></p>
   </div>
 </div>
 {% endblock %}

--- a/templates/login/login_fail.html
+++ b/templates/login/login_fail.html
@@ -1,0 +1,12 @@
+{% extends "base/base.html" %}
+{% block title %}Login Failed{% endblock %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-width-container">
+    <h1 class="govuk-heading-l">Login failed</h1>
+    <p class="govuk-body">We were unable to log you in, <a href="{% url "login" %}">please retry</a>.</p>
+    <p class="govuk-body">If the problem persists contact Analytical Platform support.</p>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
Catch login failures in the callback view, and redirect to a login fail page. Add tests.

![image](https://github.com/user-attachments/assets/cdb5a4ff-3e90-45cf-850c-a041ac9bd9ed)
