### PR TITLE
Frontend changes

### DIFF
--- a/dashboard_service/urls.py
+++ b/dashboard_service/urls.py
@@ -38,3 +38,7 @@ if settings.DEBUG and "debug_toolbar" in settings.INSTALLED_APPS:
     from debug_toolbar.toolbar import debug_toolbar_urls  # noqa
 
     urlpatterns += debug_toolbar_urls()
+    urlpatterns += [
+        path("debug/404/", views.debug_404, name="debug-404"),
+        path("debug/500/", views.debug_500, name="debug-500"),
+    ]

--- a/dashboard_service/views.py
+++ b/dashboard_service/views.py
@@ -79,3 +79,17 @@ def login_fail(request):
     if request.user.is_authenticated:
         return redirect(reverse("dashboards:index"))
     return render(request, "login/login_fail.html")
+
+
+def debug_404(request):
+    """
+    Example 404 view for the dashboard service.
+    """
+    return render(request, "404.html", status=404)
+
+
+def debug_500(request):
+    """
+    Example 500 view for the dashboard service.
+    """
+    return render(request, "500.html", status=500)

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,0 +1,21 @@
+{% extends "base/base.html" %}
+
+{% block title %}404 Not Found{% endblock title %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">Page not found</h1>
+      <p class="govuk-body">
+        If you typed the web address, check it is correct.
+      </p>
+      <p class="govuk-body">
+        If you pasted the web address, check you copied the entire address.
+      </p>
+      <p class="govuk-body">
+        If the web address is correct or you selected a link or button, please
+        <a href="mailto:analytical-platform@justice.gov.uk" class="govuk-link"> email the Analytical Platform team at analytical-platform@justice.gov.uk</a>.
+      </p>
+    </div>
+  </div>
+{% endblock content %}

--- a/templates/500.html
+++ b/templates/500.html
@@ -1,0 +1,19 @@
+{% extends "base/base.html" %}
+{% load static %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Sorry, there is a problem with the service</h1>
+    <p class="govuk-body">
+      Try again later.
+    </p>
+    <p class="govuk-body">
+      If the problem persists, please
+      <a href="mailto:analytical-platform@justice.gov.uk" class="govuk-link"> email the Analytical Platform team at analytical-platform@justice.gov.uk</a>.
+    </p>
+  </div>
+</div>
+
+{% endblock content %}

--- a/templates/base/base.html
+++ b/templates/base/base.html
@@ -32,9 +32,7 @@
   </div>
   {% endblock main %}
 
-  {% block footer %}
   {% include 'base/footer.html' %}
-  {% endblock footer %}
 
   {% block scripts %}
   {% endblock scripts %}

--- a/templates/base/base.html
+++ b/templates/base/base.html
@@ -25,7 +25,6 @@
 
   {% block main %}
   <div class="{% block base_div_class %}govuk-width-container app-width-container{% endblock base_div_class %}">
-
     <main class="govuk-main-wrapper" id="main-content" role="main">
       {% block content %}
       {% endblock content %}
@@ -33,7 +32,9 @@
   </div>
   {% endblock main %}
 
+  {% block footer %}
   {% include 'base/footer.html' %}
+  {% endblock footer %}
 
   {% block scripts %}
   {% endblock scripts %}

--- a/templates/base/header.html
+++ b/templates/base/header.html
@@ -2,10 +2,10 @@
   <div class="moj-header__container">
     <div class="moj-header__logo">
       {% include "base/moj_header.svg" %}
-      <a class="moj-header__link moj-header__link--organisation-name"
-        href="https://www.gov.uk/government/organisations/ministry-of-justice">Ministry of Justice</a>
-      <a class="moj-header__link moj-header__link--service-name"
-        href="https://github.com/ministryofjustice/analytical-platform">Analytical Platform Dashboards</a>
+      <a class="moj-header__link"href="/">
+        <span class="moj-header__link--organisation-name">Ministry of Justice</span>
+        <span class="moj-header__link--service-name">Analytical Platform Dashboards</span>
+      </a>
     </div>
     <div class="moj-header__content">
       <nav class="moj-header__navigation" aria-label="Account navigation">

--- a/templates/base/header.html
+++ b/templates/base/header.html
@@ -22,19 +22,3 @@
     </div>
   </div>
 </header>
-
-{% if request.user.is_authenticated %}
-  <div class="moj-primary-navigation">
-    <div class="moj-primary-navigation__container">
-      <div class="moj-primary-navigation__nav">
-        <nav class="moj-primary-navigation" aria-label="Primary navigation">
-          <ul class="moj-primary-navigation__list">
-            <li class="moj-primary-navigation__item">
-              <a class="moj-primary-navigation__link" aria-current="page" href="{% url "dashboards:index" %}">Dashboards</a>
-            </li>
-          </ul>
-        </nav>
-      </div>
-    </div>
-  </div>
-{% endif %}

--- a/templates/dashboards/detail.html
+++ b/templates/dashboards/detail.html
@@ -8,11 +8,11 @@
 
 {% block content %}
 
-  <h1 class="govuk-heading-l">Dashboard: {{dashboard.name }}</h1>
-  <p class="govuk-body">Admins: {{ dashboard_admins }}</p>
-
-  <div id="experience-container"></div>
-
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <div id="experience-container"></div>
+  </div>
+</div>
 
 {% endblock content %}
 

--- a/templates/dashboards/detail.html
+++ b/templates/dashboards/detail.html
@@ -95,3 +95,6 @@
     </script>
 
 {% endblock scripts %}
+
+{% block footer %}
+{% endblock footer %}

--- a/templates/dashboards/detail.html
+++ b/templates/dashboards/detail.html
@@ -10,6 +10,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l">{{ dashboard.name }}</h1>
     <div id="experience-container"></div>
   </div>
 </div>
@@ -95,6 +96,3 @@
     </script>
 
 {% endblock scripts %}
-
-{% block footer %}
-{% endblock footer %}

--- a/templates/dashboards/index.html
+++ b/templates/dashboards/index.html
@@ -2,41 +2,32 @@
 
 {% block content %}
 <div class="govuk-grid-row">
-  <div class="govuk-width-container">
+  <div class="govuk-grid-column-full">
 
-    <h1 class="govuk-heading-l">Dashboard List</h1>
+    <h1 class="govuk-heading-l">Dashboards</h1>
 
-    <table class="govuk-table">
-      <caption class="govuk-table__caption govuk-table__caption--m">Dashboards you can access</caption>
-      <thead class="govuk-table__head">
-        <tr class="govuk-table__row">
-          <th scope="col" class="govuk-table__header">Name</th>
-          <th scope="col" class="govuk-table__header">Admins</th>
-          <th scope="col" class="govuk-table__header">Action</th>
-        </tr>
-      </thead>
-      <tbody class="govuk-table__body">
-        {% for dashboard in dashboards %}
+    {% if dashboards %}
+      <table class="govuk-table">
+        <thead class="govuk-table__head">
           <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header">{{ dashboard.name }}</th>
-            <td class="govuk-table__cell">{% for admin in dashboard.admins %}{{admin.email}}{% if not forloop.last %}, {% endif %}{% endfor %}</td>
-            <td class="govuk-table__cell"><a href="{% url "dashboards:detail" quicksight_id=dashboard.quicksight_id %}">View dashboard</a></td>
+            <th scope="col" class="govuk-table__header">Name</th>
+            <th scope="col" class="govuk-table__header">Admins</th>
+            <th scope="col" class="govuk-table__header">Action</th>
           </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-
-
-
-
-    <!-- <ul class="govuk-list">
-
-    {% for dashboard in dashboards %}
-      <li>
-        <a href="{% url "dashboards:detail" quicksight_id=dashboard.quicksight_id %}">{{ dashboard.name }}</a>
-      </li>
-    {% endfor %}
-    </ul> -->
+        </thead>
+        <tbody class="govuk-table__body">
+          {% for dashboard in dashboards %}
+            <tr class="govuk-table__row">
+              <th scope="row" class="govuk-table__header">{{ dashboard.name }}</th>
+              <td class="govuk-table__cell">{% for admin in dashboard.admins %}{{admin.email}}{% if not forloop.last %}, {% endif %}{% endfor %}</td>
+              <td class="govuk-table__cell"><a href="{% url "dashboards:detail" quicksight_id=dashboard.quicksight_id %}">View dashboard</a></td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    {% else %}
+      <p class="govuk-body">You do not have access to any dashboards.</p>
+    {% endif %}
   </div>
 </div>
 {% endblock content %}


### PR DESCRIPTION
Some frontend adjustments.

- Remove the nav bar to save space. At the moment we have two pages, the dashboard list and dashboard page. Adding a have bar feels an unnecessary use of space
- Remove the list of admins from the dashboard detail page, as this saves space and reduces distance user has to scroll to view the dashboard contents
- Update the link used when clicking the header title to return user to the "Dashboard list" page
- Add 404 and 500 pages

Dashboard index without nav:
<img width="1840" alt="image" src="https://github.com/user-attachments/assets/268f247e-1eae-474e-9044-d456cd4c2322" />

Dashboard detail:
<img width="1840" alt="image" src="https://github.com/user-attachments/assets/41848120-bee5-4179-96c5-bde2f20f367c" />

404 page:
<img width="1840" alt="image" src="https://github.com/user-attachments/assets/7a442784-4f6c-44b3-955b-dc3e1ff5f0a3" />

500 page:
<img width="1840" alt="image" src="https://github.com/user-attachments/assets/897fefce-9b00-4344-868c-2cd4f6751146" />
