### PR TITLE
Remove secret key from local settings

### DIFF
--- a/dashboard_service/settings/local.py
+++ b/dashboard_service/settings/local.py
@@ -4,8 +4,6 @@ DEBUG = True
 
 ALLOWED_HOSTS = [".localhost", "127.0.0.1"]
 
-SECRET_KEY = "django-insecure-p)0zsf0h@(4$exs814m35ly%x_m8z)z!11n(z^sfl01nsfr+!r"
-
 INSTALLED_APPS += [  # noqa
     "debug_toolbar",
 ]


### PR DESCRIPTION
Even though it is only used in local development, its better to still have a SECRET_KEY defined in our `.env` files