### PR TITLE
Force reauthentication after 24 hours

### DIFF
--- a/dashboard_service/settings/common.py
+++ b/dashboard_service/settings/common.py
@@ -165,6 +165,9 @@ AUTHLIB_OAUTH_CLIENTS = {
     }
 }
 
+# Controls user session duration after which they will be logged out
+SESSION_COOKIE_AGE = int(os.environ.get("SESSION_COOKIE_AGE", 60 * 60 * 24 * 1))  # 1 day
+
 # -- Sentry error tracking
 
 if os.environ.get("SENTRY_DSN"):
@@ -183,5 +186,3 @@ if os.environ.get("SENTRY_DSN"):
 
 # Control Panel API settings
 CONTROL_PANEL_API_URL = os.environ.get("CONTROL_PANEL_API_URL")
-
-SESSION_COOKIE_AGE = int(os.environ.get("SESSION_COOKIE_AGE", 60 * 60 * 24 * 1))  # 1 day

--- a/dashboard_service/settings/common.py
+++ b/dashboard_service/settings/common.py
@@ -184,4 +184,4 @@ if os.environ.get("SENTRY_DSN"):
 # Control Panel API settings
 CONTROL_PANEL_API_URL = os.environ.get("CONTROL_PANEL_API_URL")
 
-SESSION_COOKIE_AGE = os.environ.get("SESSION_COOKIE_AGE", 60 * 60 * 24 * 1)  # 1 day
+SESSION_COOKIE_AGE = int(os.environ.get("SESSION_COOKIE_AGE", 60 * 60 * 24 * 1))  # 1 day

--- a/dashboard_service/settings/common.py
+++ b/dashboard_service/settings/common.py
@@ -158,6 +158,7 @@ AUTHLIB_OAUTH_CLIENTS = {
         "client_secret": AUTH0_CLIENT_SECRET,
         "client_kwargs": {
             "scope": "openid profile email",
+            "prompt": "login",  # forces login prompt
         },
         "server_metadata_url": f"https://{AUTH0_DOMAIN}/.well-known/openid-configuration",
         "authorize_params": {"isPasswordlessFlow": True},  # required to trigger passwordless login
@@ -182,3 +183,5 @@ if os.environ.get("SENTRY_DSN"):
 
 # Control Panel API settings
 CONTROL_PANEL_API_URL = os.environ.get("CONTROL_PANEL_API_URL")
+
+SESSION_COOKIE_AGE = os.environ.get("SESSION_COOKIE_AGE", 60 * 60 * 24 * 1)  # 1 day

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -7,9 +7,5 @@ def test_login_required_middleware_enabled():
     assert "django.contrib.auth.middleware.LoginRequiredMiddleware" in MIDDLEWARE
 
 
-def test_session_cookie_age():
-    assert settings.SESSION_COOKIE_AGE == 86400
-
-
 def test_login_prompt_set():
     assert settings.AUTHLIB_OAUTH_CLIENTS["auth0"]["client_kwargs"]["prompt"] == "login"

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,5 +1,15 @@
+from django.conf import settings
+
 from dashboard_service.settings.common import MIDDLEWARE
 
 
 def test_login_required_middleware_enabled():
     assert "django.contrib.auth.middleware.LoginRequiredMiddleware" in MIDDLEWARE
+
+
+def test_session_cookie_age():
+    assert settings.SESSION_COOKIE_AGE == 86400
+
+
+def test_login_prompt_set():
+    assert settings.AUTHLIB_OAUTH_CLIENTS["auth0"]["client_kwargs"]["prompt"] == "login"


### PR DESCRIPTION
This is enforced with two minor changes together:
- Set the default session length within django to 24 hours
- Use the 'prompt' argument when sending user to log in with Auth0. This means that even if the user is still logged in to Auth0 when the django session expires, they need to reenter their credentials again to access the Dashboard Service. Without using the 'prompt' argument, the user would be silently reauthenticated by auth0 until their session has expired.

An alternative to using 'prompt' would be to change the session length setting within Auth0. However, this change would affect all apps in the tenant, not just Dashboard Service.

### To test locally
- Add `SESSION_COOKIE_AGE` [setting ](https://docs.djangoproject.com/en/5.2/ref/settings/#session-cookie-age)to your local .env file, and set it to something short e.g. `30`
- Run the dashboard service and log in
- After success, check you are remaining logged in for however long you set the setting to
- When the time you set is up, refresh your page- you should be redirected to Auth0 and prompted to login