### PR TITLE
Feature/view moj dashboards

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["stylelint-config-standard-scss"],
+  "rules": {
+    "selector-class-pattern": "^[a-z]([a-z0-9-]+)?(__([a-z0-9]+-?)+)?(--([a-z0-9]+-?)+){0,2}$"
+  }
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ FROM public.ecr.aws/docker/library/node:24.11.1 AS build-node
 WORKDIR /build
 
 COPY package.json package-lock.json ./
-COPY /scss/app.scss ./scss/app.scss
+COPY /scss/ ./scss/
 
 RUN <<EOF
 npm install
@@ -120,6 +120,7 @@ COPY --from=build-node --chown=${CONTAINER_USER}:${CONTAINER_GROUP} /build/stati
 COPY --from=build-node --chown=${CONTAINER_USER}:${CONTAINER_GROUP} /build/node_modules/govuk-frontend/dist/govuk/assets/fonts/. ${APP_ROOT}/static/assets/fonts
 COPY --from=build-node --chown=${CONTAINER_USER}:${CONTAINER_GROUP} /build/node_modules/govuk-frontend/dist/govuk/assets/images/. ${APP_ROOT}/static/assets/images
 COPY --from=build-node --chown=${CONTAINER_USER}:${CONTAINER_GROUP} /build/node_modules/govuk-frontend/dist/govuk/govuk-frontend.min.js ${APP_ROOT}/static/assets/js/govuk-frontend.min.js
+COPY --from=build-node --chown=${CONTAINER_USER}:${CONTAINER_GROUP} /build/node_modules/@x-govuk/govuk-prototype-components/dist/govuk-prototype-components.min.js ${APP_ROOT}/static/assets/js/govuk-prototype-components.min.js
 COPY --from=build-node --chown=${CONTAINER_USER}:${CONTAINER_GROUP} /build/node_modules/@ministryofjustice/frontend/moj/assets/images/. ${APP_ROOT}/static/assets/images
 
 COPY --chown=${CONTAINER_USER}:${CONTAINER_GROUP} manage.py ${APP_ROOT}/manage.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -121,6 +121,7 @@ COPY --from=build-node --chown=${CONTAINER_USER}:${CONTAINER_GROUP} /build/node_
 COPY --from=build-node --chown=${CONTAINER_USER}:${CONTAINER_GROUP} /build/node_modules/govuk-frontend/dist/govuk/assets/images/. ${APP_ROOT}/static/assets/images
 COPY --from=build-node --chown=${CONTAINER_USER}:${CONTAINER_GROUP} /build/node_modules/govuk-frontend/dist/govuk/govuk-frontend.min.js ${APP_ROOT}/static/assets/js/govuk-frontend.min.js
 COPY --from=build-node --chown=${CONTAINER_USER}:${CONTAINER_GROUP} /build/node_modules/@x-govuk/govuk-prototype-components/dist/govuk-prototype-components.min.js ${APP_ROOT}/static/assets/js/govuk-prototype-components.min.js
+COPY --from=build-node --chown=${CONTAINER_USER}:${CONTAINER_GROUP} /build/node_modules/@x-govuk/govuk-prototype-components/dist/govuk-prototype-components.min.js.map ${APP_ROOT}/static/assets/js/govuk-prototype-components.min.js.map
 COPY --from=build-node --chown=${CONTAINER_USER}:${CONTAINER_GROUP} /build/node_modules/@ministryofjustice/frontend/moj/assets/images/. ${APP_ROOT}/static/assets/images
 
 COPY --chown=${CONTAINER_USER}:${CONTAINER_GROUP} manage.py ${APP_ROOT}/manage.py

--- a/dashboard_service/dashboards/views.py
+++ b/dashboard_service/dashboards/views.py
@@ -2,6 +2,7 @@ import requests
 import structlog
 from django.http import Http404
 from django.urls import reverse
+from django.utils.dateparse import parse_datetime
 from django.views.generic import TemplateView
 
 from dashboard_service.dashboards.api import api_client
@@ -109,9 +110,7 @@ class DetailView(TemplateView):
                 raise Http404("Dashboard not found") from e
             raise e
         context["dashboard"] = dashboard_data
-        context["dashboard_admins"] = ", ".join(
-            [admin["email"] for admin in dashboard_data["admins"]]
-        )
+        context["shared_on_datetime"] = parse_datetime(dashboard_data.get("shared_on", ""))
         return context
 
     def render_to_response(self, context, **response_kwargs):

--- a/dashboard_service/dashboards/views.py
+++ b/dashboard_service/dashboards/views.py
@@ -16,54 +16,67 @@ class IndexView(TemplateView):
 
     template_name = "dashboards/index.html"
 
-    def build_pagination_data(self, api_response, context):
+    def build_pagination_data(self, api_response, context, prefix=None):
         dashboard_url = reverse("dashboards:index")
-        if api_response["next"] or api_response["previous"]:
-            page_data = [
-                {
-                    "number": page_number,
-                    "url": f"{dashboard_url}?page={page_number}"
-                    if isinstance(page_number, int)
-                    else None,
-                    "is_elipsis": not isinstance(page_number, int),
-                }
-                for page_number in api_response["page_numbers"]
-            ]
+        if not api_response["next"] and not api_response["previous"]:
+            return None
 
-            pagination_data = {
-                "next": None,
-                "previous": None,
-                "current_page": api_response["current_page"],
-                "page_data": page_data,
-                "count": api_response["count"],
+        page_param = f"{prefix}_page" if prefix else "page"
+
+        page_data = [
+            {
+                "number": page_number,
+                "url": f"{dashboard_url}?{page_param}={page_number}"
+                if isinstance(page_number, int)
+                else None,
+                "is_elipsis": not isinstance(page_number, int),
             }
+            for page_number in api_response["page_numbers"]
+        ]
 
-            if api_response["next"]:
-                pagination_data["next"] = (
-                    f"{dashboard_url}?page={api_response['current_page'] + 1}"
-                )
+        pagination_data = {
+            "next": None,
+            "previous": None,
+            "current_page": api_response["current_page"],
+            "page_data": page_data,
+            "count": api_response["count"],
+        }
 
-            if api_response["previous"]:
-                pagination_data["previous"] = (
-                    f"{dashboard_url}?page={api_response['current_page'] - 1}"
-                )
+        if api_response["next"]:
+            pagination_data["next"] = (
+                f"{dashboard_url}?{page_param}={api_response['current_page'] + 1}"
+            )
 
-            context["pagination"] = pagination_data
+        if api_response["previous"]:
+            pagination_data["previous"] = (
+                f"{dashboard_url}?{page_param}={api_response['current_page'] - 1}"
+            )
+        context_key = f"{prefix}_pagination" if prefix else "pagination"
+        context[context_key] = pagination_data
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
-        page = self.request.GET.get("page", None)
-        params = {
-            "email": self.request.user.email,
-        }
-
-        if page is not None:
-            params["page"] = page
-
-        response = api_client.make_request("dashboards", params=params)
-        context["dashboards"] = response["results"]
-        self.build_pagination_data(response, context)
+        viewer_response = api_client.make_request(
+            "dashboards",
+            params={
+                "email": self.request.user.email,
+                "shared_via": ["viewer", "admin"],
+                "page": self.request.GET.get("viewer_page", 1),
+            },
+        )
+        domain_response = api_client.make_request(
+            "dashboards",
+            params={
+                "email": self.request.user.email,
+                "shared_via": ["domain"],
+                "page": self.request.GET.get("domain_page", 1),
+            },
+        )
+        context["viewer_dashboards"] = viewer_response["results"]
+        context["domain_dashboards"] = domain_response["results"]
+        self.build_pagination_data(viewer_response, context, prefix="viewer")
+        self.build_pagination_data(domain_response, context, prefix="domain")
         logger.info("dashboard_list_retrieved")
 
         return context

--- a/dashboard_service/dashboards/views.py
+++ b/dashboard_service/dashboards/views.py
@@ -16,17 +16,18 @@ class IndexView(TemplateView):
 
     template_name = "dashboards/index.html"
 
-    def build_pagination_data(self, api_response, context, prefix=None):
+    def build_pagination_data(self, api_response, context):
         dashboard_url = reverse("dashboards:index")
         if not api_response["next"] and not api_response["previous"]:
             return None
 
-        page_param = f"{prefix}_page" if prefix else "page"
+        shared_via = self.request.GET.get("shared_via", None)
+        shared_via_param = f"&shared_via={shared_via}" if shared_via else ""
 
         page_data = [
             {
                 "number": page_number,
-                "url": f"{dashboard_url}?{page_param}={page_number}"
+                "url": f"{dashboard_url}?page={page_number}{shared_via_param}"
                 if isinstance(page_number, int)
                 else None,
                 "is_elipsis": not isinstance(page_number, int),
@@ -44,25 +45,27 @@ class IndexView(TemplateView):
 
         if api_response["next"]:
             pagination_data["next"] = (
-                f"{dashboard_url}?{page_param}={api_response['current_page'] + 1}"
+                f"{dashboard_url}?page={api_response['current_page'] + 1}{shared_via_param}"
             )
 
         if api_response["previous"]:
             pagination_data["previous"] = (
-                f"{dashboard_url}?{page_param}={api_response['current_page'] - 1}"
+                f"{dashboard_url}?page={api_response['current_page'] - 1}{shared_via_param}"
             )
-        context_key = f"{prefix}_pagination" if prefix else "pagination"
-        context[context_key] = pagination_data
+        context["pagination"] = pagination_data
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
+        shared_via = self.request.GET.get("shared_via")
+        page = self.request.GET.get("page", 1)
         viewer_response = api_client.make_request(
             "dashboards",
             params={
                 "email": self.request.user.email,
                 "shared_via": ["viewer", "admin"],
-                "page": self.request.GET.get("viewer_page", 1),
+                "page": page if shared_via != "domain" else 1,
+                "page_size": 10,
             },
         )
         domain_response = api_client.make_request(
@@ -70,13 +73,22 @@ class IndexView(TemplateView):
             params={
                 "email": self.request.user.email,
                 "shared_via": ["domain"],
-                "page": self.request.GET.get("domain_page", 1),
+                "page": page if shared_via == "domain" else 1,
+                "page_size": 10,
             },
         )
-        context["viewer_dashboards"] = viewer_response["results"]
-        context["domain_dashboards"] = domain_response["results"]
-        self.build_pagination_data(viewer_response, context, prefix="viewer")
-        self.build_pagination_data(domain_response, context, prefix="domain")
+
+        if shared_via == "domain":
+            context["dashboards"] = domain_response["results"]
+            self.build_pagination_data(domain_response, context)
+        else:
+            context["dashboards"] = viewer_response["results"]
+            self.build_pagination_data(viewer_response, context)
+
+        context["viewer_dashboards_count"] = viewer_response["count"]
+        context["domain_dashboards_count"] = domain_response["count"]
+        email_domain = self.request.user.email.split("@")[-1]
+        context["email_domain"] = email_domain
         logger.info("dashboard_list_retrieved")
 
         return context

--- a/dashboard_service/dashboards/views.py
+++ b/dashboard_service/dashboards/views.py
@@ -16,7 +16,7 @@ class IndexView(TemplateView):
 
     template_name = "dashboards/index.html"
 
-    def build_pagination_data(self, api_response, context):
+    def build_pagination_data(self, api_response):
         dashboard_url = reverse("dashboards:index")
         if not api_response["next"] and not api_response["previous"]:
             return None
@@ -52,45 +52,42 @@ class IndexView(TemplateView):
             pagination_data["previous"] = (
                 f"{dashboard_url}?page={api_response['current_page'] - 1}{shared_via_param}"
             )
-        context["pagination"] = pagination_data
+        return pagination_data
+
+    def get_api_response(self, shared_via=None, page=1):
+        shared_via_mapping = {
+            "direct": ["viewer", "admin"],
+            "domain": ["domain"],
+        }
+        page = int(page) if page else 1
+        response = api_client.make_request(
+            "dashboards",
+            params={
+                "email": self.request.user.email,
+                "shared_via": shared_via_mapping.get(shared_via),
+                "page": page,
+                "page_size": 10,
+            },
+        )
+        return response
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
-        shared_via = self.request.GET.get("shared_via")
+        shared_via = self.request.GET.get("shared_via", "direct")
+        other = "domain" if shared_via == "direct" else "direct"
         page = self.request.GET.get("page", 1)
-        viewer_response = api_client.make_request(
-            "dashboards",
-            params={
-                "email": self.request.user.email,
-                "shared_via": ["viewer", "admin"],
-                "page": page if shared_via != "domain" else 1,
-                "page_size": 10,
-            },
-        )
-        domain_response = api_client.make_request(
-            "dashboards",
-            params={
-                "email": self.request.user.email,
-                "shared_via": ["domain"],
-                "page": page if shared_via == "domain" else 1,
-                "page_size": 10,
-            },
-        )
-
-        if shared_via == "domain":
-            context["dashboards"] = domain_response["results"]
-            self.build_pagination_data(domain_response, context)
-        else:
-            context["dashboards"] = viewer_response["results"]
-            self.build_pagination_data(viewer_response, context)
-
-        context["viewer_dashboards_count"] = viewer_response["count"]
-        context["domain_dashboards_count"] = domain_response["count"]
         email_domain = self.request.user.email.split("@")[-1]
+
+        active = self.get_api_response(shared_via=shared_via, page=page)
+        inactive = self.get_api_response(shared_via=other, page=1)
+
+        context["dashboards"] = active["results"]
+        context["pagination"] = self.build_pagination_data(active)
+        context[f"{shared_via}_dashboards_count"] = active["count"]
+        context[f"{other}_dashboards_count"] = inactive["count"]
         context["email_domain"] = email_domain
         logger.info("dashboard_list_retrieved")
-
         return context
 
 

--- a/dashboard_service/dashboards/views.py
+++ b/dashboard_service/dashboards/views.py
@@ -87,6 +87,7 @@ class IndexView(TemplateView):
         context[f"{shared_via}_dashboards_count"] = active["count"]
         context[f"{other}_dashboards_count"] = inactive["count"]
         context["email_domain"] = email_domain
+        context["domain_active"] = shared_via == "domain"
         logger.info("dashboard_list_retrieved")
         return context
 

--- a/dashboard_service/dashboards/views.py
+++ b/dashboard_service/dashboards/views.py
@@ -3,6 +3,7 @@ import structlog
 from django.http import Http404
 from django.urls import reverse
 from django.utils.dateparse import parse_datetime
+from django.utils.http import urlencode
 from django.views.generic import TemplateView
 
 from dashboard_service.dashboards.api import api_client
@@ -22,13 +23,17 @@ class IndexView(TemplateView):
         if not api_response["next"] and not api_response["previous"]:
             return None
 
-        shared_via = self.request.GET.get("shared_via", None)
-        shared_via_param = f"&shared_via={shared_via}" if shared_via else ""
+        query_params = {
+            "email": self.request.user.email,
+            "shared_via": self.request.GET.get("shared_via"),
+            "page_size": self.request.GET.get("page_size"),
+        }
+        query_string = urlencode({k: v for k, v in query_params.items() if v})
 
         page_data = [
             {
                 "number": page_number,
-                "url": f"{dashboard_url}?page={page_number}{shared_via_param}"
+                "url": f"{dashboard_url}?page={page_number}&{query_string}"
                 if isinstance(page_number, int)
                 else None,
                 "is_elipsis": not isinstance(page_number, int),
@@ -46,12 +51,12 @@ class IndexView(TemplateView):
 
         if api_response["next"]:
             pagination_data["next"] = (
-                f"{dashboard_url}?page={api_response['current_page'] + 1}{shared_via_param}"
+                f"{dashboard_url}?page={api_response['current_page'] + 1}&{query_string}"
             )
 
         if api_response["previous"]:
             pagination_data["previous"] = (
-                f"{dashboard_url}?page={api_response['current_page'] - 1}{shared_via_param}"
+                f"{dashboard_url}?page={api_response['current_page'] - 1}&{query_string}"
             )
         return pagination_data
 
@@ -67,7 +72,7 @@ class IndexView(TemplateView):
                 "email": self.request.user.email,
                 "shared_via": shared_via_mapping.get(shared_via),
                 "page": page,
-                "page_size": 10,
+                "page_size": self.request.GET.get("page_size", 10),
             },
         )
         return response
@@ -110,7 +115,7 @@ class DetailView(TemplateView):
                 raise Http404("Dashboard not found") from e
             raise e
         context["dashboard"] = dashboard_data
-        context["shared_on_datetime"] = parse_datetime(dashboard_data.get("shared_on", ""))
+        context["shared_on_datetime"] = parse_datetime(dashboard_data.get("shared_on") or "")
         return context
 
     def render_to_response(self, context, **response_kwargs):

--- a/justfile
+++ b/justfile
@@ -51,8 +51,8 @@ build-static:
 
 # Lint and format with ruff
 lint:
-    ruff check --fix
     ruff format
+    ruff check --fix
 
 # Check for migration changes
 makemigrations *ARGS:

--- a/justfile
+++ b/justfile
@@ -41,6 +41,7 @@ build-js:
     rm -rf static/assets/js
     mkdir -p static/assets/js
     cp node_modules/govuk-frontend/dist/govuk/govuk-frontend.min.js static/assets/js/govuk-frontend.min.js
+    cp node_modules/@x-govuk/govuk-prototype-components/dist/govuk-prototype-components.min.js static/assets/js/govuk-prototype-components.min.js
 
 build-static:
     rm -rf static/

--- a/justfile
+++ b/justfile
@@ -42,6 +42,7 @@ build-js:
     mkdir -p static/assets/js
     cp node_modules/govuk-frontend/dist/govuk/govuk-frontend.min.js static/assets/js/govuk-frontend.min.js
     cp node_modules/@x-govuk/govuk-prototype-components/dist/govuk-prototype-components.min.js static/assets/js/govuk-prototype-components.min.js
+    cp node_modules/@x-govuk/govuk-prototype-components/dist/govuk-prototype-components.min.js.map static/assets/js/govuk-prototype-components.min.js.map
 
 build-static:
     rm -rf static/

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@ministryofjustice/frontend": "9.0.0",
+        "@x-govuk/govuk-prototype-components": "6.0.0",
         "amazon-quicksight-embedding-sdk": "2.11.3",
         "govuk-frontend": "6.1.0"
       },
@@ -80,27 +81,6 @@
         "@parcel/watcher-win32-x64": "2.5.1"
       }
     },
-    "node_modules/@parcel/watcher-android-arm64": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.1.tgz",
-      "integrity": "sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
     "node_modules/@parcel/watcher-darwin-arm64": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.1.tgz",
@@ -122,235 +102,107 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/@parcel/watcher-darwin-x64": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.1.tgz",
-      "integrity": "sha512-1ZXDthrnNmwv10A0/3AJNZ9JGlzrF82i3gNQcWOzd7nJ8aj+ILyW1MTxVk35Db0u91oD5Nlk9MBiujMlwmeXZg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
+    "node_modules/@x-govuk/govuk-prototype-components": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@x-govuk/govuk-prototype-components/-/govuk-prototype-components-6.0.0.tgz",
+      "integrity": "sha512-yTa1rU1ePcBszPs5jWIdwuByS8OQ/4LHrTndt7HaEBJ7bj0Nh+eStobXqmUzbAAHhc1dekE99SH6rVOddZqOjg==",
       "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
+      "dependencies": {
+        "accessible-autocomplete": "^3.0.0",
+        "eventslibjs": "^1.2.0",
+        "gray-matter": "^4.0.3",
+        "nunjucks": "^3.2.4"
       },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24"
+      },
+      "peerDependencies": {
+        "govuk-frontend": "^6.0.0"
       }
     },
-    "node_modules/@parcel/watcher-freebsd-x64": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.1.tgz",
-      "integrity": "sha512-SI4eljM7Flp9yPuKi8W0ird8TI/JK6CSxju3NojVI6BjHsTyK7zxA9urjVjEKJ5MBYC+bLmMcbAWlZ+rFkLpJQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
+    "node_modules/@x-govuk/govuk-prototype-components/node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
       "license": "MIT",
       "optional": true,
-      "os": [
-        "freebsd"
-      ],
+      "peer": true,
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">= 8.10.0"
       },
       "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
       }
     },
-    "node_modules/@parcel/watcher-linux-arm-glibc": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.1.tgz",
-      "integrity": "sha512-RCdZlEyTs8geyBkkcnPWvtXLY44BCeZKmGYRtSgtwwnHR4dxfHRG3gR99XdMEdQ7KeiDdasJwwvNSF5jKtDwdA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
+    "node_modules/@x-govuk/govuk-prototype-components/node_modules/nunjucks": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.4.tgz",
+      "integrity": "sha512-26XRV6BhkgK0VOxfbU5cQI+ICFUtMLixv1noZn1tGU38kQH5A5nmmbk/O45xdyBhD1esk47nKrY0mvQpZIhRjQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "a-sync-waterfall": "^1.0.0",
+        "asap": "^2.0.3",
+        "commander": "^5.1.0"
       },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
+      "bin": {
+        "nunjucks-precompile": "bin/precompile"
+      },
+      "engines": {
+        "node": ">= 6.9.0"
+      },
+      "peerDependencies": {
+        "chokidar": "^3.3.0"
+      },
+      "peerDependenciesMeta": {
+        "chokidar": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@parcel/watcher-linux-arm-musl": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.1.tgz",
-      "integrity": "sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
+    "node_modules/@x-govuk/govuk-prototype-components/node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "license": "MIT",
       "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
+      "peer": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
       },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
+      "engines": {
+        "node": ">=8.10.0"
       }
     },
-    "node_modules/@parcel/watcher-linux-arm64-glibc": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.1.tgz",
-      "integrity": "sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
+    "node_modules/a-sync-waterfall": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
+      "integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA==",
+      "license": "MIT"
     },
-    "node_modules/@parcel/watcher-linux-arm64-musl": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.1.tgz",
-      "integrity": "sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
+    "node_modules/accessible-autocomplete": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/accessible-autocomplete/-/accessible-autocomplete-3.0.1.tgz",
+      "integrity": "sha512-xMshgc2LT5addvvfCTGzIkRrvhbOFeylFSnSMfS/PdjvvvElZkakCwxO3/yJYBWyi1hi3tZloqOJQ5kqqJtH4g==",
       "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
+      "peerDependencies": {
+        "preact": "^8.0.0"
       },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-x64-glibc": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.1.tgz",
-      "integrity": "sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-x64-musl": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.1.tgz",
-      "integrity": "sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-win32-arm64": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.1.tgz",
-      "integrity": "sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-win32-ia32": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.1.tgz",
-      "integrity": "sha512-c2KkcVN+NJmuA7CGlaGD1qJh1cLfDnQsHjE89E60vUEMlqduHGCdCLJCID5geFVM0dOtA3ZiIO8BoEQmzQVfpQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-win32-x64": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.1.tgz",
-      "integrity": "sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
+      "peerDependenciesMeta": {
+        "preact": {
+          "optional": true
+        }
       }
     },
     "node_modules/amazon-quicksight-embedding-sdk": {
@@ -364,11 +216,54 @@
         "uuid": "^9.0.0"
       }
     },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "license": "MIT"
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/braces": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -394,6 +289,15 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
@@ -408,11 +312,41 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/eventslibjs": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/eventslibjs/-/eventslibjs-1.2.0.tgz",
+      "integrity": "sha512-nui7FHXHeeZjWkQ1dZ4R3RchkT+164+y1/puiOY1Zc3CPU9W8XzAzdhqvuVQ4EJt7F/W94O5U26/oVFpBOPY3w==",
+      "license": "MIT"
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -420,6 +354,35 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/govuk-frontend": {
@@ -431,6 +394,21 @@
         "node": ">= 4.2.0"
       }
     },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
     "node_modules/immutable": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
@@ -438,11 +416,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -453,7 +453,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -467,11 +466,32 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/micromatch": {
@@ -507,11 +527,21 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "dev": true,
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -587,6 +617,19 @@
         "@parcel/watcher": "^2.4.1"
       }
     },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -597,11 +640,25 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@ministryofjustice/frontend": "9.0.0",
     "amazon-quicksight-embedding-sdk": "2.11.3",
+    "@x-govuk/govuk-prototype-components": "6.0.0",
     "govuk-frontend": "6.1.0"
   },
   "devDependencies": {

--- a/scss/app.scss
+++ b/scss/app.scss
@@ -1,12 +1,10 @@
 @use "node_modules/govuk-frontend/dist/govuk" as * with (
   $govuk-assets-path: "/static/assets/"
 );
-
 // Share config with MOJ Frontend
 @forward "node_modules/@ministryofjustice/frontend/moj/all" with (
   $moj-assets-path: $govuk-assets-path
 );
-
 @use "node_modules/@x-govuk/govuk-prototype-components/src/x-govuk";
 
 .app-width-container--full {

--- a/scss/app.scss
+++ b/scss/app.scss
@@ -1,6 +1,7 @@
 @use "node_modules/govuk-frontend/dist/govuk" as * with (
   $govuk-assets-path: "/static/assets/"
 );
+
 // Share config with MOJ Frontend
 @forward "node_modules/@ministryofjustice/frontend/moj/all" with (
   $moj-assets-path: $govuk-assets-path

--- a/scss/app.scss
+++ b/scss/app.scss
@@ -1,7 +1,10 @@
-$govuk-assets-path: "/static/assets/";
+@use "node_modules/govuk-frontend/dist/govuk" as * with (
+  $govuk-assets-path: "/static/assets/"
+);
 
-/* stylelint-disable import-notation */
-@import "node_modules/govuk-frontend/dist/govuk/index";
-@import "node_modules/@ministryofjustice/frontend/moj/all";
+// Share config with MOJ Frontend
+@forward "node_modules/@ministryofjustice/frontend/moj/all" with (
+  $moj-assets-path: $govuk-assets-path
+);
 
-/* stylelint-enable */
+@use "node_modules/@x-govuk/govuk-prototype-components/src/x-govuk";

--- a/scss/app.scss
+++ b/scss/app.scss
@@ -8,3 +8,17 @@
 );
 
 @use "node_modules/@x-govuk/govuk-prototype-components/src/x-govuk";
+
+.app-width-container--full {
+  max-width: none;
+  padding: 0 govuk-spacing(6);
+}
+
+.app-full-bleed-background {
+  background-color: govuk-colour("black", $variant: "tint-95");
+  margin-left: govuk-spacing(-6);
+  margin-right: govuk-spacing(-6);
+  padding-left: govuk-spacing(6);
+  padding-right: govuk-spacing(6);
+  padding-bottom: govuk-spacing(4);
+}

--- a/scss/app.scss
+++ b/scss/app.scss
@@ -14,11 +14,6 @@
   padding: 0 govuk-spacing(6);
 }
 
-.app-full-bleed-background {
+.app-dashboard-detail-header {
   background-color: govuk-colour("black", $variant: "tint-95");
-  margin-left: govuk-spacing(-6);
-  margin-right: govuk-spacing(-6);
-  padding-left: govuk-spacing(6);
-  padding-right: govuk-spacing(6);
-  padding-bottom: govuk-spacing(4);
 }

--- a/templates/base/base.html
+++ b/templates/base/base.html
@@ -5,7 +5,7 @@
 
 <head>
   <meta charset="utf-8">
-  <title>{% block title %}Analytical Platform Dashboards | Ministry of Justice{% endblock title %}</title>
+  <title>{% block title %}View MOJ Dashboards | Ministry of Justice{% endblock title %}</title>
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="theme-color" content="blue">
   <link rel="icon" sizes="48x48" href="{% static 'assets/images/favicon.ico' %}">

--- a/templates/base/base.html
+++ b/templates/base/base.html
@@ -31,6 +31,7 @@
 
   {% block main %}
   <div class="{% block base_div_class %}govuk-width-container app-width-container{% endblock base_div_class %}">
+    {% block back_link %}{% endblock back_link %}
     <main class="govuk-main-wrapper" id="main-content" role="main">
       {% block content %}
       {% endblock content %}

--- a/templates/base/base.html
+++ b/templates/base/base.html
@@ -5,7 +5,7 @@
 
 <head>
   <meta charset="utf-8">
-  <title>{% block title %}View MOJ Dashboards | Ministry of Justice{% endblock title %}</title>
+  <title>{% block title %}View MOJ dashboards | Ministry of Justice{% endblock title %}</title>
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <meta name="theme-color" content="blue">
   <link rel="icon" sizes="48x48" href="{% static 'assets/images/favicon.ico' %}">

--- a/templates/base/base.html
+++ b/templates/base/base.html
@@ -27,6 +27,8 @@
 
   {% include 'base/header.html' %}
 
+  {% block masthead %}{% endblock masthead %}
+
   {% block main %}
   <div class="{% block base_div_class %}govuk-width-container app-width-container{% endblock base_div_class %}">
     <main class="govuk-main-wrapper" id="main-content" role="main">

--- a/templates/base/header.html
+++ b/templates/base/header.html
@@ -4,7 +4,7 @@
       {% include "base/moj_header.svg" %}
       <a class="moj-header__link"href="/">
         <span class="moj-header__link--organisation-name">Ministry of Justice</span>
-        <span class="moj-header__link--service-name">Analytical Platform Dashboards</span>
+        <span class="moj-header__link--service-name">View MOJ Dashboards</span>
       </a>
     </div>
     <div class="moj-header__content">

--- a/templates/base/header.html
+++ b/templates/base/header.html
@@ -4,7 +4,7 @@
       {% include "base/moj_header.svg" %}
       <a class="moj-header__link"href="/">
         <span class="moj-header__link--organisation-name">Ministry of Justice</span>
-        <span class="moj-header__link--service-name">View MOJ Dashboards</span>
+        <span class="moj-header__link--service-name">View MOJ dashboards</span>
       </a>
     </div>
     <div class="moj-header__content">

--- a/templates/dashboards/detail.html
+++ b/templates/dashboards/detail.html
@@ -2,16 +2,28 @@
 
 {% block title %}{{ dashboard.name }} | {{ block.super }}{% endblock title %}
 
-{% block base_div_class %}govuk-grid-column-full{% endblock base_div_class %}
+{% block base_div_class %}govuk-width-container app-width-container--full{% endblock base_div_class %}
+
+{% block back_link %}
+  <a href="{% url "dashboards:index" %}" class="govuk-back-link">All dashboards</a>
+{% endblock back_link %}
 
 {% block content %}
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-    <h1 class="govuk-heading-l">{{ dashboard.name }}</h1>
-    <div id="dashboard-container"></div>
+<div class="app-full-bleed-background govuk-!-padding-top-6">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <h1 class="govuk-heading-xl">{{ dashboard.name }}</h1>
+      <p class="govuk-body">{{ dashboard.description }}</p>
+      <p class="govuk-body">Shared by update-me@email.com</p>
+    </div>
   </div>
 </div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <div id="dashboard-container"></div>
+  </div>
 
 {% endblock content %}
 

--- a/templates/dashboards/detail.html
+++ b/templates/dashboards/detail.html
@@ -11,8 +11,8 @@
     <div class="govuk-!-padding-top-6 govuk-!-padding-bottom-4">
       <h1 class="govuk-heading-xl">{{ dashboard.name }}</h1>
       <p class="govuk-body">{{ dashboard.description }}</p>
-      {% if dashboard.shared_by %}
-        <p class="govuk-body">Shared by {{ dashboard.shared_by }}</p>
+      {% if dashboard.shared_by_name %}
+        <p class="govuk-body"><span class="govuk-!-font-weight-bold">Shared by:</span> {{ dashboard.shared_by_name }}{% if dashboard.shared_by_email %} (<a class="govuk-link" href="mailto:{{ dashboard.shared_by_email }}">{{ dashboard.shared_by_email }}</a>){% endif %}</p>
       {% endif %}
       {% if dashboard.shared_on %}
         <p class="govuk-body-s">Shared on {{ shared_on_datetime|date:"j F Y" }}</p>

--- a/templates/dashboards/detail.html
+++ b/templates/dashboards/detail.html
@@ -2,30 +2,34 @@
 
 {% block title %}{{ dashboard.name }} | {{ block.super }}{% endblock title %}
 
-{% block base_div_class %}govuk-width-container app-width-container--full{% endblock base_div_class %}
-
-{% block back_link %}
+{% block main %}
+<div class="govuk-width-container app-width-container--full">
   <a href="{% url "dashboards:index" %}" class="govuk-back-link">All dashboards</a>
-{% endblock back_link %}
-
-{% block content %}
-
-<div class="app-full-bleed-background govuk-!-padding-top-6">
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
+</div>
+<div class="app-dashboard-detail-header">
+  <div class="govuk-width-container app-width-container--full">
+    <div class="govuk-!-padding-top-6 govuk-!-padding-bottom-4">
       <h1 class="govuk-heading-xl">{{ dashboard.name }}</h1>
       <p class="govuk-body">{{ dashboard.description }}</p>
-      <p class="govuk-body">Shared by update-me@email.com</p>
+      {% if dashboard.shared_by %}
+        <p class="govuk-body">Shared by {{ dashboard.shared_by }}</p>
+      {% endif %}
+      {% if dashboard.shared_on %}
+        <p class="govuk-body-s">Shared on {{ shared_on_datetime|date:"j F Y" }}</p>
+      {% endif %}
     </div>
   </div>
 </div>
-
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-    <div id="dashboard-container"></div>
-  </div>
-
-{% endblock content %}
+<div class="govuk-width-container app-width-container--full">
+  <main class="govuk-main-wrapper" id="main-content" role="main">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        <div id="dashboard-container"></div>
+      </div>
+    </div>
+  </main>
+</div>
+{% endblock main %}
 
 {% block scripts %}
     <script src="https://unpkg.com/amazon-quicksight-embedding-sdk@2.11.2/dist/quicksight-embedding-js-sdk.min.js"></script>

--- a/templates/dashboards/index.html
+++ b/templates/dashboards/index.html
@@ -5,7 +5,7 @@
   <div class="govuk-width-container">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds-from-desktop">
-        <h1 class="x-govuk-masthead__title">View Ministry of Justice Dashboards</h1>
+        <h1 class="x-govuk-masthead__title">View Ministry of Justice dashboards</h1>
         <p class="x-govuk-masthead__description">
           View dashboards shared with you or your organisation.
         </p>

--- a/templates/dashboards/index.html
+++ b/templates/dashboards/index.html
@@ -5,9 +5,9 @@
   <div class="govuk-width-container">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds-from-desktop">
-        <h1 class="x-govuk-masthead__title">View MOJ Dashboards</h1>
+        <h1 class="x-govuk-masthead__title">View Ministry of Justice Dashboards</h1>
         <p class="x-govuk-masthead__description">
-          View dashboards shared with you or your organisation via the Analytical Platform.
+          View dashboards shared with you or your organisation.
         </p>
       </div>
     </div>

--- a/templates/dashboards/index.html
+++ b/templates/dashboards/index.html
@@ -16,6 +16,18 @@
 {% endblock masthead %}
 
 {% block content %}
+
+<nav class="moj-sub-navigation" aria-label="Sub navigation">
+  <ul class="moj-sub-navigation__list">
+    <li class="moj-sub-navigation__item">
+      <a class="moj-sub-navigation__link" {% if not request.GET.shared_via %}aria-current="page"{% endif %} href="{% url "dashboards:index" %}">Shared with you ({{ viewer_dashboards_count }})</a>
+    </li>
+    <li class="moj-sub-navigation__item">
+      <a class="moj-sub-navigation__link" {% if request.GET.shared_via == "domain" %}aria-current="page"{% endif %} href="{% url "dashboards:index" %}?shared_via=domain">Shared with {{ email_domain }} ({{ domain_dashboards_count }})</a>
+    </li>
+  </ul>
+</nav>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
 

--- a/templates/dashboards/index.html
+++ b/templates/dashboards/index.html
@@ -20,7 +20,7 @@
 <nav class="moj-sub-navigation" aria-label="Sub navigation">
   <ul class="moj-sub-navigation__list">
     <li class="moj-sub-navigation__item">
-      <a class="moj-sub-navigation__link" {% if not request.GET.shared_via %}aria-current="page"{% endif %} href="{% url "dashboards:index" %}">Shared with you ({{ viewer_dashboards_count }})</a>
+      <a class="moj-sub-navigation__link" {% if not request.GET.shared_via %}aria-current="page"{% endif %} href="{% url "dashboards:index" %}">Shared with you ({{ direct_dashboards_count }})</a>
     </li>
     <li class="moj-sub-navigation__item">
       <a class="moj-sub-navigation__link" {% if request.GET.shared_via == "domain" %}aria-current="page"{% endif %} href="{% url "dashboards:index" %}?shared_via=domain">Shared with {{ email_domain }} ({{ domain_dashboards_count }})</a>

--- a/templates/dashboards/index.html
+++ b/templates/dashboards/index.html
@@ -53,7 +53,7 @@
           {% for dashboard in dashboards %}
             <tr class="govuk-table__row">
               <th scope="row" class="govuk-table__header">{{ dashboard.name }}</th>
-              <td class="govuk-table__cell">{{ dashboard.description }}</td>
+              <td class="govuk-table__cell">{{ dashboard.description|truncatewords:69 }}</td>
               <td class="govuk-table__cell"><a href="{% url "dashboards:detail" quicksight_id=dashboard.quicksight_id %}">View dashboard</a></td>
             </tr>
           {% endfor %}

--- a/templates/dashboards/index.html
+++ b/templates/dashboards/index.html
@@ -1,5 +1,20 @@
 {% extends "base/base.html" %}
 
+{% block masthead %}
+<div class="x-govuk-masthead x-govuk-masthead--inverse">
+  <div class="govuk-width-container">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds-from-desktop">
+        <h1 class="x-govuk-masthead__title">View MOJ Dashboards</h1>
+        <p class="x-govuk-masthead__description">
+          View dashboards shared with you or your organisation via the Analytical Platform.
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock masthead %}
+
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">

--- a/templates/dashboards/index.html
+++ b/templates/dashboards/index.html
@@ -20,40 +20,45 @@
 <nav class="moj-sub-navigation" aria-label="Sub navigation">
   <ul class="moj-sub-navigation__list">
     <li class="moj-sub-navigation__item">
-      <a class="moj-sub-navigation__link" {% if not request.GET.shared_via %}aria-current="page"{% endif %} href="{% url "dashboards:index" %}">Shared with you ({{ direct_dashboards_count }})</a>
+      <a class="moj-sub-navigation__link" {% if not domain_active %}aria-current="page"{% endif %} href="{% url "dashboards:index" %}">Shared with you ({{ direct_dashboards_count }})</a>
     </li>
     <li class="moj-sub-navigation__item">
-      <a class="moj-sub-navigation__link" {% if request.GET.shared_via == "domain" %}aria-current="page"{% endif %} href="{% url "dashboards:index" %}?shared_via=domain">Shared with {{ email_domain }} ({{ domain_dashboards_count }})</a>
+      <a class="moj-sub-navigation__link" {% if domain_active %}aria-current="page"{% endif %} href="{% url "dashboards:index" %}?shared_via=domain">Shared with {{ email_domain }} ({{ domain_dashboards_count }})</a>
     </li>
   </ul>
 </nav>
 
 <div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <h1 class="govuk-heading-l">Dashboards shared with {% if domain_active %}{{ email_domain }}{% else %}you{% endif %}</h1>
+    <p class="govuk-body">
+      {% if dashboards %}These{% else %}No{% endif %} dashboards have been shared with {% if domain_active %}everyone on the {{ email_domain }} email domain{% else %} you directly{% endif %}.
+    </p>
+    </div>
+</div>
+
+<div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-
-    <h1 class="govuk-heading-l">Dashboards</h1>
-
     {% if dashboards %}
       <table class="govuk-table">
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
-            <th scope="col" class="govuk-table__header">Name</th>
-            <th scope="col" class="govuk-table__header">Admins</th>
-            <th scope="col" class="govuk-table__header">Action</th>
+            <th scope="col" class="govuk-table__header">Dashboard name</th>
+            <th scope="col" class="govuk-table__header">Description</th>
+            <th scope="col" class="govuk-table__header"></th>
           </tr>
         </thead>
         <tbody class="govuk-table__body">
           {% for dashboard in dashboards %}
             <tr class="govuk-table__row">
               <th scope="row" class="govuk-table__header">{{ dashboard.name }}</th>
-              <td class="govuk-table__cell">{% for admin in dashboard.admins %}{{admin.email}}{% if not forloop.last %}, {% endif %}{% endfor %}</td>
+              <td class="govuk-table__cell">{{ dashboard.description }}</td>
               <td class="govuk-table__cell"><a href="{% url "dashboards:detail" quicksight_id=dashboard.quicksight_id %}">View dashboard</a></td>
             </tr>
           {% endfor %}
         </tbody>
       </table>
-    {% else %}
-      <p class="govuk-body">You do not have access to any dashboards.</p>
     {% endif %}
   </div>
 </div>

--- a/tests/dashboard_service/test_views.py
+++ b/tests/dashboard_service/test_views.py
@@ -69,12 +69,31 @@ class TestIndexView:
                 ],
                 "next": None,
                 "previous": None,
+                "count": 1,
             }
             context = view_obj.get_context_data()
 
         assert "dashboards" in context
-        assert "pagination" not in context
-        mock_make_request.assert_called_once_with("dashboards", params={"email": user.email})
+        assert context["pagination"] is None
+        assert mock_make_request.call_count == 2
+        mock_make_request.assert_any_call(
+            "dashboards",
+            params={
+                "email": user.email,
+                "shared_via": ["viewer", "admin"],
+                "page": 1,
+                "page_size": 10,
+            },
+        )
+        mock_make_request.assert_any_call(
+            "dashboards",
+            params={
+                "email": user.email,
+                "shared_via": ["domain"],
+                "page": 1,
+                "page_size": 10,
+            },
+        )
         assert any("dashboard_list_retrieved" in rec.getMessage() for rec in caplog.records)
 
     def test_get_context_data_pagination(self, api_client, view_obj, user, caplog):
@@ -99,9 +118,175 @@ class TestIndexView:
             context = view_obj.get_context_data()
 
         assert "dashboards" in context
-        assert "pagination" in context
-        mock_make_request.assert_called_once_with("dashboards", params={"email": user.email})
+        assert context["pagination"] is not None
+        assert mock_make_request.call_count == 2
         assert any("dashboard_list_retrieved" in rec.getMessage() for rec in caplog.records)
+
+    def test_get_context_data_domain_tab(self, api_client, rf, user, caplog):
+        """Test that domain tab uses domain response as active"""
+        caplog.set_level("INFO", logger="dashboard_service")
+        request = rf.get(reverse("dashboards:index"), {"shared_via": "domain"})
+        request.user = user
+        view_obj = views.IndexView()
+        view_obj.request = request
+
+        with patch.object(api_client, "make_request") as mock_make_request:
+            direct_response = {
+                "results": [{"name": "direct-dashboard", "quicksight_id": "111"}],
+                "next": None,
+                "previous": None,
+                "count": 1,
+            }
+            domain_response = {
+                "results": [{"name": "domain-dashboard", "quicksight_id": "222"}],
+                "next": None,
+                "previous": None,
+                "count": 5,
+            }
+            mock_make_request.side_effect = [domain_response, direct_response]
+            context = view_obj.get_context_data()
+
+        assert context["dashboards"] == domain_response["results"]
+        assert context["domain_dashboards_count"] == 5
+        assert context["direct_dashboards_count"] == 1
+
+    def test_get_context_data_page_forwarded_to_active_tab(self, api_client, rf, user):
+        """Test that page param is forwarded to the active tab only"""
+        request = rf.get(reverse("dashboards:index"), {"page": "3"})
+        request.user = user
+        view_obj = views.IndexView()
+        view_obj.request = request
+
+        with patch.object(api_client, "make_request") as mock_make_request:
+            mock_make_request.return_value = {
+                "results": [],
+                "next": None,
+                "previous": None,
+                "count": 0,
+            }
+            view_obj.get_context_data()
+
+        # Active tab (direct) gets page=3, inactive (domain) gets page=1
+        mock_make_request.assert_any_call(
+            "dashboards",
+            params={
+                "email": user.email,
+                "shared_via": ["viewer", "admin"],
+                "page": 3,
+                "page_size": 10,
+            },
+        )
+        mock_make_request.assert_any_call(
+            "dashboards",
+            params={
+                "email": user.email,
+                "shared_via": ["domain"],
+                "page": 1,
+                "page_size": 10,
+            },
+        )
+
+    def test_get_context_data_page_forwarded_to_domain_tab(self, api_client, rf, user):
+        """Test that page param is forwarded to domain tab when active"""
+        request = rf.get(reverse("dashboards:index"), {"shared_via": "domain", "page": "2"})
+        request.user = user
+        view_obj = views.IndexView()
+        view_obj.request = request
+
+        with patch.object(api_client, "make_request") as mock_make_request:
+            mock_make_request.return_value = {
+                "results": [],
+                "next": None,
+                "previous": None,
+                "count": 0,
+            }
+            view_obj.get_context_data()
+
+        # Active tab (domain) gets page=2, inactive (direct) gets page=1
+        mock_make_request.assert_any_call(
+            "dashboards",
+            params={
+                "email": user.email,
+                "shared_via": ["domain"],
+                "page": 2,
+                "page_size": 10,
+            },
+        )
+        mock_make_request.assert_any_call(
+            "dashboards",
+            params={
+                "email": user.email,
+                "shared_via": ["viewer", "admin"],
+                "page": 1,
+                "page_size": 10,
+            },
+        )
+
+    def test_get_context_data_context_keys(self, api_client, view_obj, user):
+        """Test that all expected context keys are set"""
+        view_obj.request.user = user
+
+        with patch.object(api_client, "make_request") as mock_make_request:
+            mock_make_request.return_value = {
+                "results": [],
+                "next": None,
+                "previous": None,
+                "count": 7,
+            }
+            context = view_obj.get_context_data()
+
+        assert context["direct_dashboards_count"] == 7
+        assert context["domain_dashboards_count"] == 7
+        assert context["email_domain"] == "example.com"
+
+    def test_build_pagination_data_includes_shared_via_in_urls(self, api_client, rf, user):
+        """Test that pagination URLs include shared_via param when on domain tab"""
+        request = rf.get(reverse("dashboards:index"), {"shared_via": "domain"})
+        request.user = user
+        view_obj = views.IndexView()
+        view_obj.request = request
+
+        api_response = {
+            "next": "next_link",
+            "previous": "prev_link",
+            "page_numbers": [1, 2, 3],
+            "current_page": 2,
+            "count": 30,
+        }
+        pagination = view_obj.build_pagination_data(api_response)
+
+        assert "&shared_via=domain" in pagination["next"]
+        assert "&shared_via=domain" in pagination["previous"]
+        for page in pagination["page_data"]:
+            if page["url"]:
+                assert "&shared_via=domain" in page["url"]
+
+    def test_build_pagination_data_no_shared_via_on_direct_tab(self, api_client, view_obj, user):
+        """Test that pagination URLs don't include shared_via on the default tab"""
+        view_obj.request.user = user
+
+        api_response = {
+            "next": "next_link",
+            "previous": "prev_link",
+            "page_numbers": [1, 2, 3],
+            "current_page": 2,
+            "count": 30,
+        }
+        pagination = view_obj.build_pagination_data(api_response)
+
+        assert "shared_via" not in pagination["next"]
+        assert "shared_via" not in pagination["previous"]
+
+    def test_build_pagination_data_returns_none_when_no_pages(self, api_client, view_obj, user):
+        """Test that build_pagination_data returns None when there's no pagination"""
+        view_obj.request.user = user
+
+        api_response = {
+            "next": None,
+            "previous": None,
+            "count": 5,
+        }
+        assert view_obj.build_pagination_data(api_response) is None
 
 
 class TestDetailView:

--- a/tests/dashboard_service/test_views.py
+++ b/tests/dashboard_service/test_views.py
@@ -301,7 +301,7 @@ class TestDetailView:
         yield view_obj
 
     @pytest.mark.django_db
-    def test_login_required(self, client, user):
+    def test_login_required(self, client, user, api_client):
         url = reverse("dashboards:detail", kwargs={"quicksight_id": "test_id"})
         response = client.get(url)
 
@@ -310,7 +310,9 @@ class TestDetailView:
 
         user.save()
         client.force_login(user)
-        response = client.get(url)
+        with patch.object(api_client, "make_request", return_value={}):
+            response = client.get(url)
+
         assert response.status_code == 200
         assert "dashboards/detail.html" in response.template_name
 
@@ -318,6 +320,7 @@ class TestDetailView:
         view_obj.request.user = user
 
         with patch.object(api_client, "make_request") as mock_make_request:
+            mock_make_request.return_value = {}
             context = view_obj.get_context_data()
 
         assert "dashboard" in context

--- a/tests/dashboard_service/test_views.py
+++ b/tests/dashboard_service/test_views.py
@@ -149,6 +149,7 @@ class TestIndexView:
         assert context["dashboards"] == domain_response["results"]
         assert context["domain_dashboards_count"] == 5
         assert context["direct_dashboards_count"] == 1
+        assert context["domain_active"] is True
 
     def test_get_context_data_page_forwarded_to_active_tab(self, api_client, rf, user):
         """Test that page param is forwarded to the active tab only"""
@@ -238,6 +239,7 @@ class TestIndexView:
         assert context["direct_dashboards_count"] == 7
         assert context["domain_dashboards_count"] == 7
         assert context["email_domain"] == "example.com"
+        assert context["domain_active"] is False
 
     def test_build_pagination_data_includes_shared_via_in_urls(self, api_client, rf, user):
         """Test that pagination URLs include shared_via param when on domain tab"""
@@ -320,15 +322,24 @@ class TestDetailView:
         view_obj.request.user = user
 
         with patch.object(api_client, "make_request") as mock_make_request:
-            mock_make_request.return_value = {}
+            mock_data = {
+                "name": "test-dashboard",
+                "quicksight_id": "123456789",
+                "shared_on": "2026-04-16T10:30:00Z",
+                "shared_by_name": "Bob Smith",
+                "shared_by_email": "bob.smith@example.com",
+            }
+            mock_make_request.return_value = mock_data
             context = view_obj.get_context_data()
 
-        assert "dashboard" in context
         mock_make_request.assert_called_once_with(
             f"dashboards/{view_obj.kwargs['quicksight_id']}",
             params={"email": user.email},
             timeout=5,
         )
+        assert "dashboard" in context
+        assert "shared_on_datetime" in context
+        assert context["dashboard"] == mock_data
 
     def test_404_raised(self, api_client, view_obj, user):
         view_obj.request.user = user
@@ -351,6 +362,26 @@ class TestDetailView:
 
             with pytest.raises(requests.exceptions.HTTPError):
                 view_obj.get_context_data()
+
+    def test_get_context_data_shared_on_parsed(self, api_client, view_obj, user):
+        view_obj.request.user = user
+
+        with patch.object(
+            api_client, "make_request", return_value={"shared_on": "2026-04-16T10:30:00Z"}
+        ):
+            context = view_obj.get_context_data()
+
+        assert context["shared_on_datetime"].year == 2026
+        assert context["shared_on_datetime"].month == 4
+        assert context["shared_on_datetime"].day == 16
+
+    def test_get_context_data_shared_on_none(self, api_client, view_obj, user):
+        view_obj.request.user = user
+
+        with patch.object(api_client, "make_request", return_value={}):
+            context = view_obj.get_context_data()
+
+        assert context["shared_on_datetime"] is None
 
     def test_render_to_response(self, api_client, view_obj, user, caplog):
         caplog.set_level("INFO", logger="dashboard_service")


### PR DESCRIPTION
Relates to https://github.com/ministryofjustice/analytical-platform/issues/9704

Implements updates to the designs, as specified on the ticket linked above.

Some refactoring was required, particularly to how the list of dashboards are retrieved from the API so that they can be displayed on two tabs (for direct viewer access, and domain access).

Related API changes can be seen [here](https://github.com/ministryofjustice/analytics-platform-control-panel/pull/1750). In order to test the changes locally, you will need to checkout that branch of Control Panel and have it running locally alongside this branch. As the new designs rely on the updated API response, this PR should only be deployed after the Control Panel PR has been merged and deployed.

Some screenshots:
<img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/490bd78f-2e22-4696-8a07-b6c16d322e2d" />
<img width="1840" height="1196" alt="image" src="https://github.com/user-attachments/assets/317fb6e0-0829-4a3b-a78f-81e199a1c41f" />

