### PR TITLE
Fix for multiple CVE alerts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -104,6 +104,8 @@ apt-get update --quiet --yes
 apt-get install --quiet --yes \
     --no-install-recommends \
     python3.12 \
+    libc6=2.39-0ubuntu8.8 \
+    libc-bin=2.39-0ubuntu8.8 \
     libncursesw6=6.4+20240113-1ubuntu2.1 \
     libtinfo6=6.4+20240113-1ubuntu2.1 \
     ncurses-base=6.4+20240113-1ubuntu2.1 \


### PR DESCRIPTION
This pull request makes a small but important update to the `Dockerfile` by specifying exact versions for some core system libraries. This helps ensure consistent and reproducible builds.

Dependency version pinning:

* Updated `apt-get install` to explicitly install `libc6=2.39-0ubuntu8.8` and `libc-bin=2.39-0ubuntu8.8` to lock these critical libraries to a specific version.